### PR TITLE
Feature/noproxy env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ actually tunneled through.
 
 container->redsocks->ctnlm->upstream
 
+For SSH you may also be interested in [corkscrew](https://github.com/bryanpkc/corkscrew)
+
 ## Usage
 
 Simple usage is 
@@ -15,6 +17,9 @@ Simple usage is
 `docker run --rm -p 3128:3128 btrepp/cntlm user.name domain NTVLMv2Hash upstream_proxy:port`
 
 This will create an unathenticated proxy on the host running at 3128
+
+By default cntlm will run with NoProxy localhost, 127.0.0.*, 10.*, 192.168.*, *.$2
+If the env var NOPROXY is set, it gets added to this list
 
 ## NTLMv2 Hash
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Cntlm Docker
+# Cntlm Docker
 
 This is a simple dockerfile that wraps up cntlm into debian. It will set up a open proxy, that uses NTLMv2 to
 authenticate upstream. The main use case is to get a simple proxy setup that plays nice with windows networks.
@@ -8,7 +8,7 @@ actually tunneled through.
 
 container->redsocks->ctnlm->upstream
 
-##Usage
+## Usage
 
 Simple usage is 
 
@@ -16,7 +16,7 @@ Simple usage is
 
 This will create an unathenticated proxy on the host running at 3128
 
-##NTLMv2 Hash
+## NTLMv2 Hash
 
 By default I've only set this up to accept Hashed passwords. cntlm supports actual passwords, but 
 that is left up to you to figure out. A script exists in the images that will help you get the hash
@@ -27,6 +27,6 @@ This will ask you for your password and attempt to use the upstream proxy to get
 succeeds it will print a PassNTLMv2 line, use this hash above when launching the container.
 
 
-##Contributing
+## Contributing
 
 This was a quick hack to get together as nothing currently existed on the registry. Feel free to fork it and send pull requests

--- a/cntlm_start.sh
+++ b/cntlm_start.sh
@@ -5,16 +5,18 @@ if [ $# -ne 4 ]; then
 fi
 
 noproxy_hosts="localhost, 127.0.0.*, 10.*, 192.168.*, *.$2"
-if [ $NOPROXY ]; then
-	noproxy_hosts="$noproxy_hosts, $NOPROXY"
+if [ -n "$NO_PROXY" ]; then
+	noproxy_hosts="$noproxy_hosts, $NO_PROXY"
 fi
 
-echo UserName $1 >> /etc/cntlm.ini
-echo Domain $2 >> /etc/cntlm.ini
-echo PassNTLMv2 $3 >> /etc/cntlm.ini
-echo Proxy $4 >> /etc/cntlm.ini
-echo NoProxy $noproxy_hosts >> /etc/cntlm.ini
-echo Gateway yes >> /etc/cntlm.ini
-echo Listen 3128 >> /etc/cntlm.ini
+cat << EOF > /etc/cntlm.conf
+UserName $1
+Domain $2
+PassNTLMv2 $3
+Proxy $4
+NoProxy $noproxy_hosts
+Gateway yes
+Listen 3128
+EOF
 
-exec /usr/sbin/cntlm -f -U cntlm -c /etc/cntlm.ini
+exec /usr/sbin/cntlm -f -U cntlm -c /etc/cntlm.conf

--- a/cntlm_start.sh
+++ b/cntlm_start.sh
@@ -3,11 +3,17 @@ if [ $# -ne 4 ]; then
 	echo "Usage: username domain NTLMv2hash upstream_proxy"
         exit 1
 fi
+
+noproxy_hosts="localhost, 127.0.0.*, 10.*, 192.168.*, *.$2"
+if [ $NOPROXY ]; then
+	noproxy_hosts="$noproxy_hosts, $NOPROXY"
+fi
+
 echo UserName $1 >> /etc/cntlm.ini
 echo Domain $2 >> /etc/cntlm.ini
 echo PassNTLMv2 $3 >> /etc/cntlm.ini
 echo Proxy $4 >> /etc/cntlm.ini
-echo NoProxy localhost, 127.0.0.*, 10.*, 192.168.*, *.$2 >> /etc/cntlm.ini
+echo NoProxy $noproxy_hosts >> /etc/cntlm.ini
 echo Gateway yes >> /etc/cntlm.ini
 echo Listen 3128 >> /etc/cntlm.ini
 


### PR DESCRIPTION
- add support for NO_PROXY in env vars
- use (default) /etc/cntlm.conf instead of .ini and overwrite instead of append